### PR TITLE
修复一个会导致程序崩溃的bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,9 @@ hexo.extend.generator.register('index-i18n', function (locals) {
   const config = this.config;
   const posts = locals.posts.sort(config.index_generator.order_by);
   const paginationDir = config.pagination_dir || 'page';
+  const languages = [].concat(config.language || []);
 
-  return config.language.filter(lang => lang !== 'default').reduce((prev, lang) => {
+  return languages.filter(lang => lang !== 'default').reduce((prev, lang) => {
     const filtedPosts = posts.filter(item => item.lang === lang);
     return prev.concat(pagination(lang, filtedPosts, {
       perPage: config.index_generator.per_page,


### PR DESCRIPTION
当`_config.yml`文件中的`language`字段为空（`config.language`为`undefined`）或者只设置了一种语言（`config.language`的类型为`string`）时，程序会崩溃。
