### PR TITLE
fix path config not being used

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,15 +33,16 @@ hexo.config.index_generator = Object.assign({
 hexo.extend.generator.register('index-i18n', function indexI18nGenerator(locals) {
   const config = this.config;
   const posts = locals.posts.sort(config.index_generator.order_by);
+  const path = config.index_generator.path || '';
   const languages = [].concat(config.language || [])
     .filter(lang => lang !== 'default');
   const defaultLanguage = languages[0];
   let indexPages = [].concat.apply([],
-    languages.map(lang => getIndexPages(lang, lang, posts, config))
+    languages.map(lang => getIndexPages(lang + '/' + path, lang, posts, config))
   );
 
   if (config.index_generator.single_language_index && defaultLanguage) {
-    indexPages = indexPages.concat(getIndexPages('', defaultLanguage, posts, config));
+    indexPages = indexPages.concat(getIndexPages(path, defaultLanguage, posts, config));
   }
 
   return indexPages;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 /* global hexo */
 const pagination = require('hexo-pagination');
+const path = require('path');
 
 /**
  * Generates translated and paginated index pages.
@@ -33,16 +34,16 @@ hexo.config.index_generator = Object.assign({
 hexo.extend.generator.register('index-i18n', function indexI18nGenerator(locals) {
   const config = this.config;
   const posts = locals.posts.sort(config.index_generator.order_by);
-  const path = config.index_generator.path || '';
+  const indexPath = config.index_generator.path || '';
   const languages = [].concat(config.language || [])
     .filter(lang => lang !== 'default');
   const defaultLanguage = languages[0];
   let indexPages = [].concat.apply([],
-    languages.map(lang => getIndexPages(lang + '/' + path, lang, posts, config))
+    languages.map(lang => getIndexPages(path.join(lang, indexPath), lang, posts, config))
   );
 
   if (config.index_generator.single_language_index && defaultLanguage) {
-    indexPages = indexPages.concat(getIndexPages(path, defaultLanguage, posts, config));
+    indexPages = indexPages.concat(getIndexPages(indexPath, defaultLanguage, posts, config));
   }
 
   return indexPages;


### PR DESCRIPTION
The path config was not being used. The README indicates that it should.

for config:
```yaml
language:
  - en
  - es
index_generator:
  path: 'blog'
```

will generate paths:
- `/en/blog/index.html`
- `/es/blog/index.html`

The only question is what is to be done about path:
- `/`
If no `index.md` in `source` directory, may return `404`

Also, the behavior for `single_language_index` should be clarified for the 3 paths listed above.